### PR TITLE
Increased amount of day/night cycle gradients.

### DIFF
--- a/lib/src/resources/config/application_colors.dart
+++ b/lib/src/resources/config/application_colors.dart
@@ -10,7 +10,7 @@ class ApplicationColors{
   static final Color twilightStartColor= Colors.indigo;
   static final Color twilightEndColor = Colors.purple;
   static final Color dawnDuskStartColor = Colors.indigo;
-  static final Color dawnDuskEndColod = Colors.pinkAccent;
+  static final Color dawnDuskEndColor = Colors.pinkAccent;
   static final Color morningEveStartColor = Colors.blue.shade700;
   static final Color morningEveEndColor = Colors.pink.shade200;
   static final Color dayStartColor = Colors.blue.shade700;

--- a/lib/src/resources/config/application_colors.dart
+++ b/lib/src/resources/config/application_colors.dart
@@ -3,10 +3,20 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 
 class ApplicationColors{
-  static final Color nightStartGradientColor = Color(0xFF4286f4);
-  static final Color nightEndGradient = Color(0xFF373B44);
-  static final Color dayStartGradientColor = Color(0x0fffdbb2d);
-  static final Color dayEndGradientColor = Color(0x0FF22c1c3);
+  static final Color midnightStartColor = Colors.black;
+  static final Color midnightEndColor = Colors.deepPurple.shade900;
+  static final Color nightStartColor = Colors.deepPurple.shade900;
+  static final Color nightEndColor = Colors.indigo;
+  static final Color twilightStartColor= Colors.indigo;
+  static final Color twilightEndColor = Colors.purple;
+  static final Color dawnDuskStartColor = Colors.indigo;
+  static final Color dawnDuskEndColod = Colors.pinkAccent;
+  static final Color morningEveStartColor = Colors.blue.shade700;
+  static final Color morningEveEndColor = Colors.pink.shade200;
+  static final Color dayStartColor = Colors.blue.shade700;
+  static final Color dayEndColor = Colors.lightBlue.shade300;
+  static final Color middayStartColor = Colors.blue;
+  static final Color middayEndColor = Colors.lightBlue.shade100;
   static final Color swiperInactiveDotColor = Colors.white54;
   static final Color swiperActiveDotColor = Colors.white;
 }

--- a/lib/src/ui/screen/weather_main_screen.dart
+++ b/lib/src/ui/screen/weather_main_screen.dart
@@ -11,8 +11,8 @@ class WeatherMainScreen extends StatelessWidget {
             key: Key("weather_main_screen_container"),
             decoration: BoxDecoration(
                 gradient: WidgetHelper.buildGradient(
-                    ApplicationColors.nightStartGradientColor,
-                    ApplicationColors.nightEndGradient)),
+                    ApplicationColors.nightStartColor,
+                    ApplicationColors.nightEndColor)),
             child: WeatherMainWidget()));
   }
 }

--- a/lib/src/ui/widget/widget_helper.dart
+++ b/lib/src/ui/widget/widget_helper.dart
@@ -115,7 +115,7 @@ static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
       double percentage = (nowMs - sunriseMs) / (sunsetMs - sunriseMs);
       if(percentage <= 0.2 || percentage >= 0.8) {
         return WidgetHelper.buildGradient(
-          ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+          ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor);
       } else if (percentage <= 0.4) {
         return WidgetHelper.buildGradient(
           ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);

--- a/lib/src/ui/widget/widget_helper.dart
+++ b/lib/src/ui/widget/widget_helper.dart
@@ -132,8 +132,8 @@ static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
   static LinearGradient getGradient({sunriseTime = 0, sunsetTime = 0}) {
     if (sunriseTime == 0 && sunsetTime == 0) {
       return WidgetHelper.buildGradient(
-          ApplicationColors.nightStartGradientColor,
-          ApplicationColors.nightEndGradient);
+          ApplicationColors.midnightStartColor,
+          ApplicationColors.midnightEndColor);
     } else {
       return buildGradientBasedOnDayCycle(sunriseTime, sunsetTime);
     }

--- a/lib/src/ui/widget/widget_helper.dart
+++ b/lib/src/ui/widget/widget_helper.dart
@@ -98,41 +98,31 @@ static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
 
   static LinearGradient getNightGradient(double percentage) {
     if (percentage <= 0.1) {
-        return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
-            ApplicationColors.dawnDuskEndColor);
+        return buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor);
       } else if (percentage <= 0.2) {
-        return WidgetHelper.buildGradient(ApplicationColors.twilightStartColor,
-            ApplicationColors.twilightEndColor);
+        return buildGradient(ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
       } else if (percentage <= 0.6) {
-        return WidgetHelper.buildGradient(
-            ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+        return buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
       } else {
-        return WidgetHelper.buildGradient(ApplicationColors.midnightStartColor,
-            ApplicationColors.midnightEndColor);
+        return buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
       }
   }
 
   static LinearGradient getDayGradient(double percentage) {
     if (percentage <= 0.1 || percentage >= 0.9) {
-      return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
-          ApplicationColors.dawnDuskEndColor);
+      return buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor);
     } else if (percentage <= 0.2 || percentage >= 0.8) {
-      return WidgetHelper.buildGradient(ApplicationColors.morningEveStartColor,
-          ApplicationColors.morningEveEndColor);
+      return buildGradient(ApplicationColors.morningEveStartColor, ApplicationColors.morningEveEndColor);
     } else if (percentage <= 0.4 || percentage >= 0.6) {
-      return WidgetHelper.buildGradient(
-          ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
+      return buildGradient(ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
     } else {
-      return WidgetHelper.buildGradient(
-          ApplicationColors.middayStartColor, ApplicationColors.middayEndColor);
+      return buildGradient(ApplicationColors.middayStartColor, ApplicationColors.middayEndColor);
     }
   }
 
   static LinearGradient getGradient({sunriseTime = 0, sunsetTime = 0}) {
     if (sunriseTime == 0 && sunsetTime == 0) {
-      return WidgetHelper.buildGradient(
-          ApplicationColors.midnightStartColor,
-          ApplicationColors.midnightEndColor);
+      return buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
     } else {
       return buildGradientBasedOnDayCycle(sunriseTime, sunsetTime);
     }

--- a/lib/src/ui/widget/widget_helper.dart
+++ b/lib/src/ui/widget/widget_helper.dart
@@ -85,46 +85,58 @@ static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
     int sunriseMs = sunrise * 1000;
     int sunsetMs = sunset * 1000;
 
-    if(nowMs < sunriseMs) {
-      int lastMidnight = new DateTime(now.year, now.month, now.day).millisecondsSinceEpoch;
+    if (nowMs < sunriseMs) {
+      int lastMidnight =
+          new DateTime(now.year, now.month, now.day).millisecondsSinceEpoch;
       double percentage = (sunriseMs - nowMs) / (sunriseMs - lastMidnight);
-      if(percentage >= 0.6) {
-        return WidgetHelper.buildGradient(
-          ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
+      if (percentage >= 0.6) {
+        return WidgetHelper.buildGradient(ApplicationColors.midnightStartColor,
+            ApplicationColors.midnightEndColor);
       } else if (percentage >= 0.2) {
         return WidgetHelper.buildGradient(
-          ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+            ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+      } else if (percentage >= 0.1) {
+        return WidgetHelper.buildGradient(ApplicationColors.twilightStartColor,
+            ApplicationColors.twilightEndColor);
       } else {
-        return WidgetHelper.buildGradient(
-          ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+        return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
+            ApplicationColors.dawnDuskEndColor);
       }
     } else if (nowMs > sunsetMs) {
-      int nextMidnight = new DateTime(now.year, now.month, now.day+1).millisecondsSinceEpoch;
+      int nextMidnight =
+          new DateTime(now.year, now.month, now.day + 1).millisecondsSinceEpoch;
       double percentage = (nowMs - sunsetMs) / (nextMidnight - sunsetMs);
-      if(percentage <= 0.2) {
-        return WidgetHelper.buildGradient(
-          ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+      if (percentage <= 0.1) {
+        return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
+            ApplicationColors.dawnDuskEndColor);
+      } else if (percentage <= 0.2) {
+        return WidgetHelper.buildGradient(ApplicationColors.twilightStartColor,
+            ApplicationColors.twilightEndColor);
       } else if (percentage <= 0.6) {
         return WidgetHelper.buildGradient(
-          ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+            ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
       } else {
-        return WidgetHelper.buildGradient(
-          ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
+        return WidgetHelper.buildGradient(ApplicationColors.midnightStartColor,
+            ApplicationColors.midnightEndColor);
       }
     } else {
       double percentage = (nowMs - sunriseMs) / (sunsetMs - sunriseMs);
-      if(percentage <= 0.2 || percentage >= 0.8) {
+      if (percentage <= 0.1 || percentage >= 0.9) {
+        return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
+            ApplicationColors.dawnDuskEndColor);
+      } else if (percentage <= 0.2 || percentage >= 0.8) {
         return WidgetHelper.buildGradient(
-          ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor);
+            ApplicationColors.morningEveStartColor,
+            ApplicationColors.morningEveEndColor);
       } else if (percentage <= 0.4) {
         return WidgetHelper.buildGradient(
-          ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
+            ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
       } else if (percentage <= 0.6) {
-        return WidgetHelper.buildGradient(
-          ApplicationColors.middayStartColor, ApplicationColors.middayEndColor);
+        return WidgetHelper.buildGradient(ApplicationColors.middayStartColor,
+            ApplicationColors.middayEndColor);
       } else {
         return WidgetHelper.buildGradient(
-          ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
+            ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
       }
     }
   }

--- a/lib/src/ui/widget/widget_helper.dart
+++ b/lib/src/ui/widget/widget_helper.dart
@@ -79,16 +79,53 @@ class WidgetHelper {
                     children: widgets))));
   }
 
-  static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
-    int currentTime = DateTime.now().millisecondsSinceEpoch;
+static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
+    DateTime now = new DateTime.now();
+    int nowMs = now.millisecondsSinceEpoch;
     int sunriseMs = sunrise * 1000;
     int sunsetMs = sunset * 1000;
-    if (currentTime > sunriseMs && currentTime < sunsetMs) {
-      return buildGradient(ApplicationColors.dayStartGradientColor,
-          ApplicationColors.dayEndGradientColor);
+
+    if(nowMs < sunriseMs) {
+      int lastMidnight = new DateTime(now.year, now.month, now.day).millisecondsSinceEpoch;
+      double percentage = (sunriseMs - nowMs) / (sunriseMs - lastMidnight);
+      if(percentage >= 0.6) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
+      } else if (percentage >= 0.2) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+      } else {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+      }
+    } else if (nowMs > sunsetMs) {
+      int nextMidnight = new DateTime(now.year, now.month, now.day+1).millisecondsSinceEpoch;
+      double percentage = (nowMs - sunsetMs) / (nextMidnight - sunsetMs);
+      if(percentage <= 0.2) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+      } else if (percentage <= 0.6) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+      } else {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
+      }
     } else {
-      return buildGradient(ApplicationColors.nightStartGradientColor,
-          ApplicationColors.nightEndGradient);
+      double percentage = (nowMs - sunriseMs) / (sunsetMs - sunriseMs);
+      if(percentage <= 0.2 || percentage >= 0.8) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+      } else if (percentage <= 0.4) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
+      } else if (percentage <= 0.6) {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.middayStartColor, ApplicationColors.middayEndColor);
+      } else {
+        return WidgetHelper.buildGradient(
+          ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
+      }
     }
   }
 

--- a/lib/src/ui/widget/widget_helper.dart
+++ b/lib/src/ui/widget/widget_helper.dart
@@ -86,27 +86,18 @@ static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
     int sunsetMs = sunset * 1000;
 
     if (nowMs < sunriseMs) {
-      int lastMidnight =
-          new DateTime(now.year, now.month, now.day).millisecondsSinceEpoch;
-      double percentage = (sunriseMs - nowMs) / (sunriseMs - lastMidnight);
-      if (percentage >= 0.6) {
-        return WidgetHelper.buildGradient(ApplicationColors.midnightStartColor,
-            ApplicationColors.midnightEndColor);
-      } else if (percentage >= 0.2) {
-        return WidgetHelper.buildGradient(
-            ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
-      } else if (percentage >= 0.1) {
-        return WidgetHelper.buildGradient(ApplicationColors.twilightStartColor,
-            ApplicationColors.twilightEndColor);
-      } else {
-        return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
-            ApplicationColors.dawnDuskEndColor);
-      }
+      int lastMidnight = new DateTime(now.year, now.month, now.day).millisecondsSinceEpoch;
+      return getNightGradient((sunriseMs - nowMs) / (sunriseMs - lastMidnight));
     } else if (nowMs > sunsetMs) {
-      int nextMidnight =
-          new DateTime(now.year, now.month, now.day + 1).millisecondsSinceEpoch;
-      double percentage = (nowMs - sunsetMs) / (nextMidnight - sunsetMs);
-      if (percentage <= 0.1) {
+      int nextMidnight = new DateTime(now.year, now.month, now.day + 1).millisecondsSinceEpoch;
+      return getNightGradient((nowMs - sunsetMs) / (nextMidnight - sunsetMs));
+    } else {
+      return getDayGradient((nowMs - sunriseMs) / (sunsetMs - sunriseMs));
+    }
+  }
+
+  static LinearGradient getNightGradient(double percentage) {
+    if (percentage <= 0.1) {
         return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
             ApplicationColors.dawnDuskEndColor);
       } else if (percentage <= 0.2) {
@@ -119,25 +110,21 @@ static LinearGradient buildGradientBasedOnDayCycle(int sunrise, int sunset) {
         return WidgetHelper.buildGradient(ApplicationColors.midnightStartColor,
             ApplicationColors.midnightEndColor);
       }
+  }
+
+  static LinearGradient getDayGradient(double percentage) {
+    if (percentage <= 0.1 || percentage >= 0.9) {
+      return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
+          ApplicationColors.dawnDuskEndColor);
+    } else if (percentage <= 0.2 || percentage >= 0.8) {
+      return WidgetHelper.buildGradient(ApplicationColors.morningEveStartColor,
+          ApplicationColors.morningEveEndColor);
+    } else if (percentage <= 0.4 || percentage >= 0.6) {
+      return WidgetHelper.buildGradient(
+          ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
     } else {
-      double percentage = (nowMs - sunriseMs) / (sunsetMs - sunriseMs);
-      if (percentage <= 0.1 || percentage >= 0.9) {
-        return WidgetHelper.buildGradient(ApplicationColors.dawnDuskStartColor,
-            ApplicationColors.dawnDuskEndColor);
-      } else if (percentage <= 0.2 || percentage >= 0.8) {
-        return WidgetHelper.buildGradient(
-            ApplicationColors.morningEveStartColor,
-            ApplicationColors.morningEveEndColor);
-      } else if (percentage <= 0.4) {
-        return WidgetHelper.buildGradient(
-            ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
-      } else if (percentage <= 0.6) {
-        return WidgetHelper.buildGradient(ApplicationColors.middayStartColor,
-            ApplicationColors.middayEndColor);
-      } else {
-        return WidgetHelper.buildGradient(
-            ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
-      }
+      return WidgetHelper.buildGradient(
+          ApplicationColors.middayStartColor, ApplicationColors.middayEndColor);
     }
   }
 

--- a/test/gradient_cycle_test.dart
+++ b/test/gradient_cycle_test.dart
@@ -60,35 +60,78 @@ void main() {
       return getDayGradient((testMs - sunriseMs) / (sunsetMs - sunriseMs));
     }
   }
-  test('testing gradient cycle', () {
+  
+  test('testing midnight before sunrise gradient', () {
     // Test > 0.6 for midnight
     expect(testGradientCycle(0, 0), buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor));
+  });
+
+  test('testing night before sunrise gradient', () {
     // Test < 0.6 for night
     expect(testGradientCycle(4, 0), buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor));
+  });
+
+  test('testing twilight before sunrise gradient', () {
     // Test < 0.2 for twilight
     expect(testGradientCycle(7, 0), buildGradient(ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor));
+  });
+
+  test('testing dawn before sunrise gradient', () {
     // Test < 0.1 for dawn before sunrise
     expect(testGradientCycle(7, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+  });
+
+  test('testing dawn after sunrise gradient', () {
     // Test < 0.1 for for dawn after sunrise
     expect(testGradientCycle(8, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+  });
+
+  test('testing morning after sunrise gradient', () {
     // Test < 0.2 for morning
     expect(testGradientCycle(10, 0), buildGradient(ApplicationColors.morningEveStartColor, ApplicationColors.morningEveEndColor));
+  });
+
+  test('testing day before midday gradient', () {
     // Test < 0.4 for day
     expect(testGradientCycle(11, 0), buildGradient(ApplicationColors.dayStartColor, ApplicationColors.dayEndColor));
+  });
+
+  test('testing midday gradient', () {
     // Test > 0.4 and < 0.6 for midday
     expect(testGradientCycle(13, 0), buildGradient(ApplicationColors.middayStartColor, ApplicationColors.middayEndColor));
+  });
+
+  test('testing day after midday gradient', () {
     // Test > 0.6 for day
     expect(testGradientCycle(14, 0), buildGradient(ApplicationColors.dayStartColor, ApplicationColors.dayEndColor));
+  });
+
+  test('testing evening before sunset gradient', () {
     // Test > 0.8 for evening
     expect(testGradientCycle(16, 30), buildGradient(ApplicationColors.morningEveStartColor, ApplicationColors.morningEveEndColor));
+  });
+
+  test('testing dusk before sunset gradient', () {
     // Test > 0.9 for dusk before sunset
     expect(testGradientCycle(17, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+  });
+
+  test('testing dusk after sunset gradient', () {
     // Test < 0.1 for for dawn after sunset
     expect(testGradientCycle(18, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+  });
+
+  test('testing twilight after sunset gradient', () {
     // Test < 0.2 for twilight
     expect(testGradientCycle(19, 0), buildGradient(ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor));
+  });
+
+  test('testing night after sunset gradient', () {
     // Test < 0.6 for
     expect(testGradientCycle(20, 0), buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor));
+  });
+
+  test('testing midnight after sunset gradient', () {
     // Test > 0.6 for midnight
     expect(testGradientCycle(23, 0), buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor));
   });

--- a/test/gradient_cycle_test.dart
+++ b/test/gradient_cycle_test.dart
@@ -1,0 +1,96 @@
+
+import 'package:feather/src/resources/config/application_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+
+  LinearGradient buildGradient(Color startColor, Color endColor) {
+    return LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      stops: [0.2, 0.99],
+      colors: [
+        startColor,
+        endColor,
+      ],
+    );
+  }
+
+  LinearGradient getNightGradient(double percentage) {
+    if (percentage <= 0.1) {
+        return buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor);
+      } else if (percentage <= 0.2) {
+        return buildGradient(ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor);
+      } else if (percentage <= 0.6) {
+        return buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor);
+      } else {
+        return buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor);
+      }
+  }
+
+  LinearGradient getDayGradient(double percentage) {
+    if (percentage <= 0.1 || percentage >= 0.9) {
+      return buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor);
+    } else if (percentage <= 0.2 || percentage >= 0.8) {
+      return buildGradient(ApplicationColors.morningEveStartColor, ApplicationColors.morningEveEndColor);
+    } else if (percentage <= 0.4 || percentage >= 0.6) {
+      return buildGradient(ApplicationColors.dayStartColor, ApplicationColors.dayEndColor);
+    } else {
+      return buildGradient(ApplicationColors.middayStartColor, ApplicationColors.middayEndColor);
+    }
+  }
+
+  LinearGradient testGradientCycle(int testHour, testMinutes){
+
+    DateTime testDate = new DateTime.now();
+    int testMs = new DateTime(testDate.year, testDate.month, testDate.day, testHour, testMinutes).millisecondsSinceEpoch;
+    // Test sunrise is at 08:00
+    int sunriseMs = new DateTime(testDate.year, testDate.month, testDate.day, 8).millisecondsSinceEpoch;
+    // Test sunset is at 18:00
+    int sunsetMs = new DateTime(testDate.year, testDate.month, testDate.day, 18).millisecondsSinceEpoch;
+
+    if (testMs < sunriseMs) {
+      int lastMidnight = new DateTime(testDate.year, testDate.month, testDate.day).millisecondsSinceEpoch;
+      return getNightGradient((sunriseMs - testMs) / (sunriseMs - lastMidnight));
+    } else if (testMs > sunsetMs) {
+      int nextMidnight = new DateTime(testDate.year, testDate.month, testDate.day + 1).millisecondsSinceEpoch;
+      return getNightGradient((testMs - sunsetMs) / (nextMidnight - sunsetMs));
+    } else {
+      return getDayGradient((testMs - sunriseMs) / (sunsetMs - sunriseMs));
+    }
+  }
+  test('testing gradient cycle', () {
+    // Test > 0.6 for midnight
+    expect(testGradientCycle(0, 0), buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor));
+    // Test < 0.6 for night
+    expect(testGradientCycle(4, 0), buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor));
+    // Test < 0.2 for twilight
+    expect(testGradientCycle(7, 0), buildGradient(ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor));
+    // Test < 0.1 for dawn before sunrise
+    expect(testGradientCycle(7, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+    // Test < 0.1 for for dawn after sunrise
+    expect(testGradientCycle(8, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+    // Test < 0.2 for morning
+    expect(testGradientCycle(10, 0), buildGradient(ApplicationColors.morningEveStartColor, ApplicationColors.morningEveEndColor));
+    // Test < 0.4 for day
+    expect(testGradientCycle(11, 0), buildGradient(ApplicationColors.dayStartColor, ApplicationColors.dayEndColor));
+    // Test > 0.4 and < 0.6 for midday
+    expect(testGradientCycle(13, 0), buildGradient(ApplicationColors.middayStartColor, ApplicationColors.middayEndColor));
+    // Test > 0.6 for day
+    expect(testGradientCycle(14, 0), buildGradient(ApplicationColors.dayStartColor, ApplicationColors.dayEndColor));
+    // Test > 0.8 for evening
+    expect(testGradientCycle(16, 30), buildGradient(ApplicationColors.morningEveStartColor, ApplicationColors.morningEveEndColor));
+    // Test > 0.9 for dusk before sunset
+    expect(testGradientCycle(17, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+    // Test < 0.1 for for dawn after sunset
+    expect(testGradientCycle(18, 30), buildGradient(ApplicationColors.dawnDuskStartColor, ApplicationColors.dawnDuskEndColor));
+    // Test < 0.2 for twilight
+    expect(testGradientCycle(19, 0), buildGradient(ApplicationColors.twilightStartColor, ApplicationColors.twilightEndColor));
+    // Test < 0.6 for
+    expect(testGradientCycle(20, 0), buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor));
+    // Test > 0.6 for midnight
+    expect(testGradientCycle(23, 0), buildGradient(ApplicationColors.midnightStartColor, ApplicationColors.midnightEndColor));
+  });
+
+}

--- a/test/gradient_cycle_test.dart
+++ b/test/gradient_cycle_test.dart
@@ -127,7 +127,7 @@ void main() {
   });
 
   test('testing night after sunset gradient', () {
-    // Test < 0.6 for
+    // Test < 0.6 for night
     expect(testGradientCycle(20, 0), buildGradient(ApplicationColors.nightStartColor, ApplicationColors.nightEndColor));
   });
 


### PR DESCRIPTION
I've added upon the app's functionality of setting the background gradient based on day/night cycles by implementing more stages. The cycle will now go in the order of: midnight, night, twilight, dawn/dusk, morning/eve, day, midday, and then vice versa. These values are based upon the percentage of the current time from the `lastMidnight`, `sunrise`, `sunset` and `nextMidnight` values. 

Here are the background gradients I have chosen:
![](https://i.imgur.com/4jmy5Zk.jpg)

I used just the standard Flutter `Color` class for generating these but if you feel like you want to provide better, more custom colours for these stages then go ahead!

Let me know what you think.